### PR TITLE
Support WebP article images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add safe incremental entry and image generation backed by SHA-256 metadata.
 - Preserve malformed `meta.toml` files and report actionable errors.
+- Decode WebP article images and emit correctly named JPEG artifacts.
 - Generate unique TOC anchors from rendered headings and keep the TOC visible while scrolling.
 - Bundle production CSS instead of loading Tailwind Play CDN at runtime.
 - Add configuration validation, `-c` / `--config` CLI support, and CI on JDK 21.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ recentEntryCount = 10
 The bundled templates use a precompiled `/assets/pologen.css` containing the required Tailwind CSS, daisyUI, and Typography styles. The generator copies that stylesheet and `/assets/pologen.js` into the document root, so generated pages do not depend on Tailwind Play CDN at runtime. Custom assets are appended after these defaults.
 
 ## Image Handling
-Markdown image syntax (`![alt](photo.jpg)`) renders responsive figures: Pologen resolves the image relative to the post folder, emits `photo-full.jpg` and `photo-thumb.jpg` with the configured sizes, and injects HTML that opens the full asset. The output is always encoded as JPEG regardless of the supported source image format, so the file extension matches its content. Unchanged image sources are reused using SHA-256 fingerprints stored in `meta.toml`.
+Markdown image syntax (`![alt](photo.jpg)`) renders responsive figures: Pologen resolves JPEG, PNG, GIF, and WebP input relative to the post folder, emits `photo-full.jpg` and `photo-thumb.jpg` with the configured sizes, and injects HTML that opens the full asset. The output is always encoded as JPEG, so the file extension matches its content. Unchanged image sources are reused using SHA-256 fingerprints stored in `meta.toml`.
 
 ## Custom Assets
 If you need extra CSS or JS beyond the defaults, declare `[assets] stylesheets = ["..."]` or `scripts = ["..."]` in `config.toml`. Pologen keeps the bundled CSS and image-overlay/TOC helper and loads your assets afterwards.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation("gg.jte:jte-kotlin:3.2.1")
     implementation("org.imgscalr:imgscalr-lib:4.2")
     implementation("org.jsoup:jsoup:1.22.1")
+    implementation("com.twelvemonkeys.imageio:imageio-webp:3.13.1")
 }
 
 tasks.test {

--- a/src/test/kotlin/ImageProcessorSpec.kt
+++ b/src/test/kotlin/ImageProcessorSpec.kt
@@ -8,6 +8,7 @@ import java.awt.Color
 import java.awt.image.BufferedImage
 import java.nio.file.Files
 import java.nio.file.attribute.FileTime
+import java.util.Base64
 import javax.imageio.ImageIO
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.readBytes
@@ -50,5 +51,30 @@ class ImageProcessorSpec : FunSpec({
 
         (changed.images.single().sourceSha256 == artifact.sourceSha256) shouldBe false
         (Files.getLastModifiedTime(dir.resolve(artifact.fullPath)) == oldTime) shouldBe false
+    }
+
+    test("WebP input produces JPEG artifacts") {
+        val dir = createTempDirectory("pologen-webp-")
+        val source = dir.resolve("sample.webp")
+        Files.write(
+            source,
+            Base64.getDecoder().decode(
+                "UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEAAUAmJaQAA3AA/vuUAAA="
+            )
+        )
+
+        val result = MarkdownImageProcessor().process(
+            "![sample](sample.webp)",
+            dir,
+            ImagesConfig(),
+        )
+
+        val artifact = result.images.single()
+        artifact.fullPath shouldBe "sample-full.jpg"
+        artifact.thumbPath shouldBe "sample-thumb.jpg"
+        dir.resolve(artifact.fullPath).readBytes().take(2) shouldBe
+            listOf(0xff.toByte(), 0xd8.toByte())
+        dir.resolve(artifact.thumbPath).readBytes().take(2) shouldBe
+            listOf(0xff.toByte(), 0xd8.toByte())
     }
 })


### PR DESCRIPTION
WebP記事画像をImageIOでデコードし、既存の画像処理経路からJPEG成果物を生成できるようにします。

変更内容:
- TwelveMonkeys WebP ImageIOプロバイダーを追加
- 1x1 WebP入力からfull・thumb JPEGを生成する回帰テストを追加
- JPEG、PNG、GIF、WebPの対応形式をREADMEに明記

検証:
- ./gradlew test --tests jp.yappo.pologen.ImageProcessorSpec
- ./gradlew test shadowJar
- git diff --check