### PR TITLE
Test complete incremental artifact reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add safe incremental entry and image generation backed by SHA-256 metadata.
 - Preserve malformed `meta.toml` files and report actionable errors.
 - Decode WebP article images and emit correctly named JPEG artifacts.
+- Verify that unchanged builds preserve article, image, OGP, and metadata artifacts.
 - Generate unique TOC anchors from rendered headings and keep the TOC visible while scrolling.
 - Bundle production CSS instead of loading Tailwind Play CDN at runtime.
 - Add configuration validation, `-c` / `--config` CLI support, and CI on JDK 21.

--- a/src/test/kotlin/IncrementalBuildSpec.kt
+++ b/src/test/kotlin/IncrementalBuildSpec.kt
@@ -2,8 +2,14 @@ package jp.yappo.pologen
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import jp.yappo.pologen.domain.config.OgpConfig
 import jp.yappo.pologen.infrastructure.markdown.MarkdownService
 import jp.yappo.pologen.infrastructure.rendering.SiteRenderer
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.nio.file.Files
+import java.nio.file.attribute.FileTime
+import javax.imageio.ImageIO
 import kotlin.io.path.createDirectories
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.exists
@@ -30,5 +36,46 @@ class IncrementalBuildSpec : FunSpec({
         )
         val third = service.collectEntries(changedConfiguration, root, root).single()
         third.needsRender shouldBe true
+    }
+
+    test("second build preserves article image and OGP artifacts") {
+        val root = createTempDirectory("pologen-incremental-artifacts-")
+        val entryDir = root.resolve("post").also { it.createDirectories() }
+        entryDir.resolve("index.md").writeText("title: Entry\n\n![sample](sample.png)\n\nBody")
+        val sourceImage = BufferedImage(24, 24, BufferedImage.TYPE_INT_RGB).apply {
+            val graphics = createGraphics()
+            graphics.color = Color.ORANGE
+            graphics.fillRect(0, 0, width, height)
+            graphics.dispose()
+        }
+        ImageIO.write(sourceImage, "png", entryDir.resolve("sample.png").toFile())
+        val service = MarkdownService()
+        val renderer = SiteRenderer()
+        val configuration = sampleConfiguration().copy(
+            ogp = OgpConfig(enabled = true, width = 320, height = 168),
+        )
+
+        val first = service.collectEntries(configuration, root, root).single()
+        first.needsRender shouldBe true
+        renderer.renderEntries(configuration, listOf(first))
+
+        val artifacts = listOf(
+            entryDir.resolve("index.html"),
+            entryDir.resolve("sample-full.jpg"),
+            entryDir.resolve("sample-thumb.jpg"),
+            entryDir.resolve("ogp.png"),
+            entryDir.resolve("meta.toml"),
+        )
+        artifacts.all { it.exists() } shouldBe true
+        val unchangedTime = FileTime.fromMillis(1_000_000)
+        artifacts.forEach { Files.setLastModifiedTime(it, unchangedTime) }
+
+        val second = service.collectEntries(configuration, root, root).single()
+        second.needsRender shouldBe false
+        renderer.renderEntries(configuration, listOf(second))
+
+        artifacts.forEach { artifact ->
+            Files.getLastModifiedTime(artifact) shouldBe unchangedTime
+        }
     }
 })


### PR DESCRIPTION
同一入力の2回目生成で記事と派生成果物が書き換えられないことを統合テストで固定します。

検証対象:
- 記事index.html
- full JPEG
- thumbnail JPEG
- OGP画像
- meta.toml

各ファイルの更新時刻を固定した後に再生成し、記事が再利用状態となり全更新時刻が維持されることを確認します。

検証:
- ./gradlew test --tests jp.yappo.pologen.IncrementalBuildSpec
- ./gradlew test shadowJar
- git diff --check