### PR TITLE
Add custom template directory support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Decode WebP article images and emit correctly named JPEG artifacts.
 - Verify that unchanged builds preserve article, image, OGP, and metadata artifacts.
 - Run responsive mobile and sticky TOC regressions in Chromium.
+- Load a complete custom jte template directory relative to `config.toml`.
 - Generate unique TOC anchors from rendered headings and keep the TOC visible while scrolling.
 - Bundle production CSS instead of loading Tailwind Play CDN at runtime.
 - Add configuration validation, `-c` / `--config` CLI support, and CI on JDK 21.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ authorIconPath = "/absolute/or/relative/path/to/author_icon.png"
 stylesheets = ["/assets/custom.css"]
 scripts = ["/assets/custom.js"]
 
+[templates]
+directory = "templates"
+
 [sidebar]
 recentEntryCount = 10
 
@@ -72,9 +75,12 @@ recentEntryCount = 10
 - `images.*` governs thumbnail/full-size resizing and JPEG quality; `scaleMethod` accepts `speed`, `balanced`, `quality`, `ultra_quality`, or `automatic`. Widths must be positive and `jpegQuality` must be between `0.0` and `1.0`.
 - `sidebar.recentEntryCount` controls how many items appear in the “Recent posts” card; the `[links]` table is an insertion-order map rendered as external links in the sidebar (quote keys like `"Community Portal"` if they contain spaces).
 - The `[ogp]` table enables/disables image generation and configures the canvas, colors, and optional font/author icon assets. If `enabled = false`, OGP rendering and meta tags are skipped entirely.
+- `templates.directory` optionally selects a directory containing `entry.kte`, `index.kte`, and `feed.kte`. Relative paths resolve from `config.toml`; omitting the table keeps the bundled templates. Template files are trusted executable jte/Kotlin input.
 
 ## Styling Defaults
 The bundled templates use a precompiled `/assets/pologen.css` containing the required Tailwind CSS, daisyUI, and Typography styles. The generator copies that stylesheet and `/assets/pologen.js` into the document root, so generated pages do not depend on Tailwind Play CDN at runtime. Custom assets are appended after these defaults.
+
+To customize page structure, copy all three bundled templates from `src/main/resources/templates` into the configured `templates.directory` and edit them together. Generation fails before writing output when the directory or a required template is missing. Changing a custom template invalidates cached entry HTML.
 
 ## Image Handling
 Markdown image syntax (`![alt](photo.jpg)`) renders responsive figures: Pologen resolves JPEG, PNG, GIF, and WebP input relative to the post folder, emits `photo-full.jpg` and `photo-thumb.jpg` with the configured sizes, and injects HTML that opens the full asset. The output is always encoded as JPEG, so the file extension matches its content. Unchanged image sources are reused using SHA-256 fingerprints stored in `meta.toml`.

--- a/src/main/kotlin/jp/yappo/pologen/domain/config/Configuration.kt
+++ b/src/main/kotlin/jp/yappo/pologen/domain/config/Configuration.kt
@@ -20,6 +20,7 @@ data class Configuration(
     val images: ImagesConfig = ImagesConfig(),
     val ogp: OgpConfig = OgpConfig(),
     val sidebar: SidebarConfig = SidebarConfig(),
+    val templates: TemplatesConfig = TemplatesConfig(),
     val links: Map<String, String> = emptyMap(),
 )
 
@@ -79,6 +80,11 @@ data class OgpConfig(
 @Serializable
 data class SidebarConfig(
     val recentEntryCount: Int = 10,
+)
+
+@Serializable
+data class TemplatesConfig(
+    val directory: String? = null,
 )
 
 @Serializable

--- a/src/main/kotlin/jp/yappo/pologen/infrastructure/config/ConfigurationLoader.kt
+++ b/src/main/kotlin/jp/yappo/pologen/infrastructure/config/ConfigurationLoader.kt
@@ -4,6 +4,7 @@ import com.akuleshov7.ktoml.file.TomlFileReader
 import jp.yappo.pologen.application.port.ConfigurationReader
 import jp.yappo.pologen.domain.config.Configuration
 import java.net.URI
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.isRegularFile
 
@@ -14,7 +15,18 @@ class ConfigurationLoader(
         require(path.isRegularFile()) {
             "Configuration file does not exist: $path"
         }
-        return reader.decodeFromFile(Configuration.serializer(), path.toString()).also(::validateConfiguration)
+        val decoded = reader.decodeFromFile(Configuration.serializer(), path.toString())
+        val configBaseDir = path.toAbsolutePath().normalize().parent
+        val resolved = decoded.copy(
+            templates = decoded.templates.copy(
+                directory = decoded.templates.directory?.let { configuredPath ->
+                    configBaseDir.resolve(configuredPath).normalize().toString()
+                }
+            )
+        )
+        validateConfiguration(resolved)
+        validateTemplateDirectory(resolved)
+        return resolved
     }
 }
 
@@ -29,6 +41,9 @@ internal fun validateConfiguration(configuration: Configuration) {
     require(configuration.images.fullMaxWidth > 0) { "images.fullMaxWidth must be greater than zero" }
     require(configuration.images.jpegQuality in 0.0f..1.0f) { "images.jpegQuality must be between 0.0 and 1.0" }
     require(configuration.sidebar.recentEntryCount >= 0) { "sidebar.recentEntryCount must not be negative" }
+    require(configuration.templates.directory?.isNotBlank() != false) {
+        "templates.directory must not be blank"
+    }
     if (configuration.ogp.enabled) {
         require(configuration.ogp.width > 0) { "ogp.width must be greater than zero" }
         require(configuration.ogp.height > 0) { "ogp.height must be greater than zero" }
@@ -43,3 +58,17 @@ internal fun validateConfiguration(configuration: Configuration) {
         "site.documentBaseUrl must be an absolute HTTP or HTTPS URL without a query or fragment"
     }
 }
+
+private fun validateTemplateDirectory(configuration: Configuration) {
+    val directory = configuration.templates.directory?.let(Path::of) ?: return
+    require(Files.isDirectory(directory)) {
+        "templates.directory does not exist or is not a directory: $directory"
+    }
+    REQUIRED_TEMPLATES.forEach { templateName ->
+        require(Files.isRegularFile(directory.resolve(templateName))) {
+            "Custom template is missing: ${directory.resolve(templateName)}"
+        }
+    }
+}
+
+private val REQUIRED_TEMPLATES = listOf("entry.kte", "index.kte", "feed.kte")

--- a/src/main/kotlin/jp/yappo/pologen/infrastructure/markdown/MarkdownService.kt
+++ b/src/main/kotlin/jp/yappo/pologen/infrastructure/markdown/MarkdownService.kt
@@ -34,7 +34,7 @@ class MarkdownService(
             createDraft(rootDirPath, filePath, newEntryPublishDate)
         }
         val renderConfigSha256 = sha256Hex(
-            "$ENTRY_CACHE_VERSION|${templateFingerprint()}|${configBaseDir.toAbsolutePath().normalize()}|$conf"
+            "$ENTRY_CACHE_VERSION|${templateFingerprint(conf, configBaseDir)}|${configBaseDir.toAbsolutePath().normalize()}|$conf"
         )
         val navigationSha256 = sha256Hex(
             drafts.joinToString("\n") { "${it.urlPath}|${it.title}|${it.publishDate}" }
@@ -203,9 +203,22 @@ class MarkdownService(
 
     private fun rssDate(value: String, zoneId: ZoneId): String = convertToRssDateTimeFormat(value, JST, zoneId)
 
-    private fun templateFingerprint(): String {
+    private fun templateFingerprint(conf: Configuration, configBaseDir: Path): String {
+        val customDirectory = conf.templates.directory?.let { configuredPath ->
+            val path = Path.of(configuredPath)
+            if (path.isAbsolute) path.normalize() else configBaseDir.resolve(path).normalize()
+        }
+        if (customDirectory != null) {
+            val fingerprints = TEMPLATE_NAMES.map { templateName ->
+                val templatePath = customDirectory.resolve(templateName)
+                require(templatePath.isRegularFile()) { "Custom template is missing: $templatePath" }
+                sha256Hex(templatePath)
+            }
+            return sha256Hex(fingerprints.joinToString("|"))
+        }
         val classLoader = MarkdownService::class.java.classLoader
-        val fingerprints = TEMPLATE_RESOURCES.map { resourcePath ->
+        val fingerprints = TEMPLATE_NAMES.map { templateName ->
+            val resourcePath = "templates/$templateName"
             val bytes = requireNotNull(classLoader.getResourceAsStream(resourcePath)) {
                 "Bundled template is missing: $resourcePath"
             }.use { it.readBytes() }
@@ -228,6 +241,6 @@ class MarkdownService(
     private companion object {
         val JST: ZoneId = ZoneId.of("Asia/Tokyo")
         val GMT: ZoneId = ZoneId.of("GMT")
-        val TEMPLATE_RESOURCES = listOf("templates/entry.kte", "templates/index.kte", "templates/feed.kte")
+        val TEMPLATE_NAMES = listOf("entry.kte", "index.kte", "feed.kte")
     }
 }

--- a/src/main/kotlin/jp/yappo/pologen/infrastructure/rendering/Templates.kt
+++ b/src/main/kotlin/jp/yappo/pologen/infrastructure/rendering/Templates.kt
@@ -1,8 +1,10 @@
 package jp.yappo.pologen.infrastructure.rendering
 
 import gg.jte.ContentType
+import gg.jte.CodeResolver
 import gg.jte.TemplateEngine
 import gg.jte.output.StringOutput
+import gg.jte.resolve.DirectoryCodeResolver
 import gg.jte.resolve.ResourceCodeResolver
 import jp.yappo.pologen.domain.config.Configuration
 import jp.yappo.pologen.domain.model.Entry
@@ -12,7 +14,9 @@ import org.apache.commons.text.StringEscapeUtils
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.nio.file.Path
 import java.util.LinkedHashMap
+import java.util.concurrent.ConcurrentHashMap
 
 data class AuthorMeta(
     val name: String,
@@ -89,6 +93,7 @@ object Templates {
 
     private val htmlTemplateEngine: TemplateEngine by lazy { createEngine(ContentType.Html) }
     private val plainTemplateEngine: TemplateEngine by lazy { createEngine(ContentType.Plain) }
+    private val customTemplateEngines = ConcurrentHashMap<TemplateEngineKey, TemplateEngine>()
 
     fun renderEntry(conf: Configuration, entry: Entry, recentEntries: List<RecentEntry>): String {
         val permalink = resolveDocumentUrl(conf.site.documentBaseUrl, entry.urlPath)
@@ -107,7 +112,7 @@ object Templates {
             rssUrl = conf.site.feedXmlUrl,
         )
         val output = StringOutput()
-        htmlTemplateEngine.render("entry.kte", model, output)
+        templateEngine(conf, ContentType.Html).render("entry.kte", model, output)
         return output.toString()
     }
 
@@ -129,7 +134,7 @@ object Templates {
             rssUrl = conf.site.feedXmlUrl,
         )
         val output = StringOutput()
-        htmlTemplateEngine.render("index.kte", model, output)
+        templateEngine(conf, ContentType.Html).render("index.kte", model, output)
         return output.toString()
     }
 
@@ -154,7 +159,7 @@ object Templates {
             siteDescriptionEscaped = StringEscapeUtils.escapeXml10(conf.site.description),
         )
         val output = StringOutput()
-        plainTemplateEngine.render("feed.kte", model, output)
+        templateEngine(conf, ContentType.Plain).render("feed.kte", model, output)
         return output.toString()
     }
 
@@ -178,11 +183,26 @@ object Templates {
         )
     }
 
-    private fun createEngine(contentType: ContentType): TemplateEngine {
+    private fun templateEngine(conf: Configuration, contentType: ContentType): TemplateEngine {
+        val customDirectory = conf.templates.directory?.let { Path.of(it).toAbsolutePath().normalize() }
+        if (customDirectory == null) {
+            return if (contentType == ContentType.Html) htmlTemplateEngine else plainTemplateEngine
+        }
+        val key = TemplateEngineKey(customDirectory, contentType)
+        return customTemplateEngines.computeIfAbsent(key) {
+            createEngine(contentType, customDirectory)
+        }
+    }
+
+    private fun createEngine(contentType: ContentType, customDirectory: Path? = null): TemplateEngine {
         val classDirectory = Files.createTempDirectory("pologen-jte-${contentType.name.lowercase()}").apply {
             toFile().deleteOnExit()
         }
-        val resolver = ResourceCodeResolver("templates")
+        val resolver: CodeResolver = if (customDirectory == null) {
+            ResourceCodeResolver("templates")
+        } else {
+            DirectoryCodeResolver(customDirectory)
+        }
         val parentClassLoader = Templates::class.java.classLoader
         return TemplateEngine.create(resolver, classDirectory, contentType, parentClassLoader)
     }
@@ -200,6 +220,11 @@ object Templates {
         )
     }
 }
+
+private data class TemplateEngineKey(
+    val directory: Path,
+    val contentType: ContentType,
+)
 
 data class ShareTarget(
     val name: String,

--- a/src/test/kotlin/CustomTemplateSpec.kt
+++ b/src/test/kotlin/CustomTemplateSpec.kt
@@ -1,0 +1,119 @@
+package jp.yappo.pologen
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import jp.yappo.pologen.domain.config.TemplatesConfig
+import jp.yappo.pologen.infrastructure.config.ConfigurationLoader
+import jp.yappo.pologen.infrastructure.markdown.MarkdownService
+import jp.yappo.pologen.infrastructure.rendering.SiteRenderer
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+class CustomTemplateSpec : FunSpec({
+    test("configuration resolves a complete custom template directory relative to config.toml") {
+        val root = createTempDirectory("pologen-custom-template-config-")
+        val templateDir = root.resolve("templates").also { it.createDirectories() }
+        writeCustomTemplates(templateDir, "CUSTOM")
+        val configPath = root.resolve("config.toml")
+        configPath.writeText(configurationToml())
+
+        val configuration = ConfigurationLoader().load(configPath)
+
+        configuration.templates.directory shouldBe templateDir.toString()
+    }
+
+    test("configuration rejects an incomplete custom template directory") {
+        val root = createTempDirectory("pologen-custom-template-missing-")
+        val templateDir = root.resolve("templates").also { it.createDirectories() }
+        templateDir.resolve("entry.kte").writeText("entry")
+        templateDir.resolve("index.kte").writeText("index")
+        val configPath = root.resolve("config.toml")
+        configPath.writeText(configurationToml())
+
+        val error = shouldThrow<IllegalArgumentException> {
+            ConfigurationLoader().load(configPath)
+        }
+
+        error.message shouldContain templateDir.resolve("feed.kte").toString()
+    }
+
+    test("custom templates render all outputs and changes invalidate cached entries") {
+        val root = createTempDirectory("pologen-custom-template-render-")
+        val entryDir = root.resolve("post").also { it.createDirectories() }
+        entryDir.resolve("index.md").writeText("title: Custom entry\n\nBody")
+        val templateDir = root.resolve("templates").also { it.createDirectories() }
+        writeCustomTemplates(templateDir, "FIRST")
+        val configuration = sampleConfiguration().copy(
+            templates = TemplatesConfig(directory = templateDir.toString()),
+        )
+        val service = MarkdownService()
+        val renderer = SiteRenderer()
+
+        val first = service.collectEntries(configuration, root, root).single()
+        renderer.renderEntries(configuration, listOf(first))
+        renderer.renderIndex(configuration, root.resolve("index.html"), listOf(first))
+        renderer.renderFeed(configuration, root.resolve("feed.xml"), listOf(first))
+        entryDir.resolve("index.html").readText() shouldContain "FIRST ENTRY Custom entry"
+        root.resolve("index.html").readText() shouldContain "FIRST INDEX 1"
+        root.resolve("feed.xml").readText() shouldContain "FIRST FEED 1"
+
+        service.collectEntries(configuration, root, root).single().needsRender shouldBe false
+        writeCustomTemplates(templateDir, "SECOND")
+
+        val changed = service.collectEntries(configuration, root, root).single()
+        changed.needsRender shouldBe true
+        renderer.renderEntries(configuration, listOf(changed))
+        entryDir.resolve("index.html").readText() shouldContain "SECOND ENTRY Custom entry"
+    }
+})
+
+private fun writeCustomTemplates(directory: java.nio.file.Path, marker: String) {
+    directory.resolve("entry.kte").writeText(
+        """
+        @import jp.yappo.pologen.infrastructure.rendering.EntryPageModel
+        @param model:EntryPageModel
+        $marker ENTRY ${'$'}{model.title}
+        """.trimIndent()
+    )
+    directory.resolve("index.kte").writeText(
+        """
+        @import jp.yappo.pologen.infrastructure.rendering.IndexPageModel
+        @param model:IndexPageModel
+        $marker INDEX ${'$'}{model.entries.size}
+        """.trimIndent()
+    )
+    directory.resolve("feed.kte").writeText(
+        """
+        @import jp.yappo.pologen.infrastructure.rendering.FeedPageModel
+        @param model:FeedPageModel
+        $marker FEED ${'$'}{model.entries.size}
+        """.trimIndent()
+    )
+}
+
+private fun configurationToml(): String =
+    """
+    [paths]
+    documentRoot = "docs"
+    indexHtml = "index.html"
+    feedXml = "feed.xml"
+
+    [site]
+    blogTopUrl = "/"
+    documentBaseUrl = "https://example.com"
+    feedXmlUrl = "/feed.xml"
+    title = "Example Site"
+    description = "Example Description"
+
+    [author]
+    name = "@example"
+    url = "https://example.com/me"
+    iconUrl = "https://example.com/me.png"
+
+    [templates]
+    directory = "templates"
+    """.trimIndent()


### PR DESCRIPTION
config.tomlからカスタムjteテンプレート一式を選択できるようにします。

仕様:
- templates.directoryはconfig.tomlの位置を基準に解決
- entry.kte、index.kte、feed.kteの3ファイルを必須化
- 未指定時は従来の同梱テンプレートを使用
- 不足ファイルは生成開始前に対象パス付きで失敗
- カスタムテンプレート変更時は記事キャッシュを無効化
- テンプレートは信頼済みのjte/Kotlin入力としてREADMEに明記

検証:
- カスタム3出力の描画
- 相対パス解決
- 不足ファイル拒否
- テンプレート変更後の再生成
- 全Kotlinテスト、shadowJar、Chromiumテスト

Closes #1