### PR TITLE
Update Kotlin to 2.2.21

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.1.10" />
+    <option name="version" value="2.2.21" />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     application
-    kotlin("jvm") version "2.1.10"
-    kotlin("plugin.serialization") version "2.1.10"
+    kotlin("jvm") version "2.2.21"
+    kotlin("plugin.serialization") version "2.2.21"
     id("com.gradleup.shadow") version "9.1.0"
 }
 


### PR DESCRIPTION
## Summary
- update the Kotlin JVM and serialization plugins from 2.1.10 to 2.2.21
- keep the IntelliJ Kotlin compiler setting aligned
- retain project version 1.0-SNAPSHOT

## Testing
- ./gradlew clean test shadowJar --no-daemon --console=plain
- npm run build:css
- npm run test:e2e
- git diff --check