### PR TITLE
Update Commons Text to 1.15.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
 
     // App deps
     implementation("org.jetbrains:markdown:0.7.3")
-    implementation("org.apache.commons:commons-text:1.10.0")
+    implementation("org.apache.commons:commons-text:1.15.0")
     implementation("com.akuleshov7:ktoml-core:0.7.1")
     implementation("com.akuleshov7:ktoml-file:0.7.1")
     implementation("gg.jte:jte:3.2.1")


### PR DESCRIPTION
## Summary
- update Apache Commons Text from 1.10.0 to 1.15.0
- keep the dependency update isolated for compatibility review
- retain project version 1.0-SNAPSHOT

## Testing
- ./gradlew clean test shadowJar --no-daemon --console=plain
- npm run build:css
- npm run test:e2e
- git diff --check