### PR TITLE
Restore plain article title compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Generate unique TOC anchors from rendered headings and keep the TOC visible while scrolling.
 - Bundle production CSS instead of loading Tailwind Play CDN at runtime.
 - Add configuration validation, `-c` / `--config` CLI support, and CI on JDK 21.
+- Preserve the original plain first-line article title format alongside `title: Your Title`.
 - Update Kotlin to 2.2.21, Commons Text to 1.15.0, and jte to 3.2.3.
 
 The application version remains `1.0-SNAPSHOT` until a stable release is intentionally prepared.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ If you need extra CSS or JS beyond the defaults, declare `[assets] stylesheets =
 Entry pages include an X share button that opens an X.com posting intent in a new tab. Web Share API and copy-link controls are not currently provided.
 
 ## Content Layout
-Each post resides in its own directory beneath `paths.documentRoot` and must contain an `index.md`. Its first line must use the `title: Your Title` format; invalid entries stop generation with the offending path. The remainder is parsed with JetBrains Markdown and rendered into HTML. The generator maintains a `meta.toml` alongside each entry with publication/update dates, summaries, TOC data, source/configuration fingerprints, and generated-image fingerprints. The legacy `bodyMd5` key is retained for compatibility but contains a SHA-256 body digest. An unreadable `meta.toml` is reported and never overwritten automatically.
+Each post resides in its own directory beneath `paths.documentRoot` and must contain an `index.md`. Its first line contains the article title. Both the original plain-title form (`Your Title`) and the explicit `title: Your Title` form are supported, so existing posts do not need migration. An empty title stops generation with the offending path. The remainder is parsed with JetBrains Markdown and rendered into HTML. The generator maintains a `meta.toml` alongside each entry with publication/update dates, summaries, TOC data, source/configuration fingerprints, and generated-image fingerprints. The legacy `bodyMd5` key is retained for compatibility but contains a SHA-256 body digest. An unreadable `meta.toml` is reported and never overwritten automatically.
 
 When tags are used, put a comma-separated declaration directly on the second line. Duplicate names within an entry are removed while display spelling is preserved:
 
@@ -117,7 +117,7 @@ Article body starts here.
 ```
 
 ### Markdown heading rules
-- The top-of-page title is rendered as an `<h1>` from the `title:` line, so keep in-body headings at `##` (h2) or deeper. In-body `#` headings are intentionally excluded from TOC generation.
+- The top-of-page title is rendered as an `<h1>` from the first line, so keep in-body headings at `##` (h2) or deeper. In-body `#` headings are intentionally excluded from TOC generation.
 - TOC entries are derived from rendered h2/h3 elements, ignore headings inside code fences, and receive unique anchors when headings repeat. On larger screens the TOC remains visible while the article scrolls.
 
 ## Generated Output

--- a/src/main/kotlin/jp/yappo/pologen/infrastructure/markdown/MarkdownService.kt
+++ b/src/main/kotlin/jp/yappo/pologen/infrastructure/markdown/MarkdownService.kt
@@ -66,10 +66,20 @@ class MarkdownService(
     private fun createDraft(rootDirPath: Path, filePath: Path, newEntryPublishDate: String): EntryDraft {
         val lines = Files.readAllLines(filePath)
         val titleLine = lines.firstOrNull()
-        require(titleLine?.startsWith("title: ") == true && titleLine.removePrefix("title: ").isNotBlank()) {
-            "The first line of $filePath must use the format: title: Your Title"
+        val title = requireNotNull(
+            titleLine
+                ?.let { line ->
+                    when {
+                        line.startsWith("title: ") -> line.removePrefix("title: ")
+                        line == "title:" -> ""
+                        else -> line
+                    }
+                }
+                ?.trim()
+                ?.takeIf(String::isNotBlank)
+        ) {
+            "The first line of $filePath must contain an article title, either as plain text or as: title: Your Title"
         }
-        val title = titleLine.removePrefix("title: ").trim()
         val tagsLine = lines.getOrNull(1)?.takeIf { it.startsWith("tags:") }
         val tags = tagsLine
             ?.removePrefix("tags:")

--- a/src/test/kotlin/MarkdownAndEntrySpec.kt
+++ b/src/test/kotlin/MarkdownAndEntrySpec.kt
@@ -91,9 +91,20 @@ class MarkdownAndEntrySpec : FunSpec({
         list.map { it.urlPath } shouldContainAll listOf("/a/", "/b/")
     }
 
-    test("entry requires an explicit title line") {
+    test("legacy plain first-line title remains supported") {
         val root = createTempDirectory("pologen-title-")
-        root.resolve("index.md").writeText("# Missing title prefix\nBody")
+        root.resolve("index.md").writeText("Legacy article title\ntags: Legacy, Kotlin\n\nBody")
+
+        val entry = MarkdownService().collectEntries(sampleConfiguration(), root, root, root).single()
+
+        entry.title shouldBe "Legacy article title"
+        entry.tags shouldBe listOf("Legacy", "Kotlin")
+        entry.markdown shouldBe "Body"
+    }
+
+    test("entry rejects an empty first-line title") {
+        val root = createTempDirectory("pologen-empty-title-")
+        root.resolve("index.md").writeText("\nBody")
 
         shouldThrow<IllegalArgumentException> {
             MarkdownService().collectEntries(sampleConfiguration(), root, root, root)


### PR DESCRIPTION
## Summary
- accept the original plain first-line article title format again
- continue to support the newer explicit title: Your Title format
- retain second-line tag parsing for both title formats
- document both supported forms and add a regression test

## Context
The existing blog contains 12 posts whose first line is the plain article title. Requiring a title: prefix broke all of them after the generation audit changes.

## Testing
- ./gradlew clean test shadowJar --no-daemon --console=plain
- npm run test:e2e
- generated a temporary copy of all 12 blog posts with the new jar and OGP enabled; all 12 completed successfully
- git diff --check

The original blog directory was not modified.